### PR TITLE
Add env variable for backend URL

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,7 +18,7 @@ export default function App({ queryClient }: { queryClient: QueryClient }) {
     trpc.createClient({
       links: [
         httpBatchLink({
-          url: 'http://localhost:3001',
+          url: import.meta.env?.BACKEND_URL ?? 'http://localhost:3001',
           // You can pass any HTTP headers you wish here
           async headers() {
             const token = await getToken();

--- a/client/src/env.d.ts
+++ b/client/src/env.d.ts
@@ -9,6 +9,7 @@ interface ImportMetaEnv {
   readonly VITE_PROJECT_ID: string;
   readonly VITE_AUTH_DOMAIN: string;
   readonly VITE_API_KEY: string;
+  readonly BACKEND_URL: string;
   // more env variables...
 }
 


### PR DESCRIPTION
- Add environment variable for backend URL. If not found, will default to local URL so will not break any dev environments if environment variable not present. 